### PR TITLE
update parquet version  1.11.1 and avro version 1.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <!-- note that this should be compatible with Kafka brokers version 0.10 and up -->
     <kafka.version>2.6.0</kafka.version>
     <derby.version>10.12.1.1</derby.version>
-    <parquet.version>1.10.1</parquet.version>
+    <parquet.version>1.11.1</parquet.version>
     <orc.version>1.5.12</orc.version>
     <jetty.version>9.4.28.v20200408</jetty.version>
     <javaxservlet.version>3.1.0</javaxservlet.version>
@@ -147,7 +147,7 @@
     the link to metrics.dropwizard.io in docs/monitoring.md.
     -->
     <codahale.metrics.version>4.1.1</codahale.metrics.version>
-    <avro.version>1.8.2</avro.version>
+    <avro.version>1.9.2</avro.version>
     <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
     <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>
     <!-- Should be consistent with Kinesis client dependency -->


### PR DESCRIPTION
update parquet version  1.11.1 and avro version 1.9.2, iceberg rely on these versions